### PR TITLE
Fix flask crafting and clean-up rare map crafting

### DIFF
--- a/Resources/item_processing.py
+++ b/Resources/item_processing.py
@@ -11,9 +11,9 @@ class ItemRarity(StrEnum):
     RARE = 'Rare'
     UNIQUE = 'Unique'
 
-ITEM_BASE_REGEX = re.compile(r"^Item Class: (?P<class>\w*)$\s*^Rarity:\s(?P<rarity>\w*)$.*^(?P<corrupted>Corrupted)?$", re.MULTILINE | re.DOTALL)
+ITEM_BASE_REGEX = re.compile(r"^Item Class: (?P<class>[\w ]*)$\s*^Rarity:\s(?P<rarity>\w*)$.*^(?P<corrupted>Corrupted)?$", re.MULTILINE | re.DOTALL)
 AFFIX_REGEX = re.compile(
-    r"^{ (?:Master Crafted )?(?P<affix_type>Prefix|Suffix) Modifier \"(?P<affix_name>[\w\s'-]*)\" (?:\((?P<tier>(?:Rank|Tier): \d*)\))?[^(?:\r\n|\n|\r)]*$(?:\r\n|\n|\r)(?P<description>[^{]*)(?={?)",
+    r"^{ (?:Master Crafted )?(?P<affix_type>Prefix|Suffix) Modifier \"(?P<affix_name>[\w\s'-]*)\" (?:\((?P<tier>(?:Rank|Tier): \d*)\))?[^(?:\r\n|\n|\r)]*$(?:\r\n|\n|\r)(?P<description>[^{]*?)(?=(?:\n\n))",
     re.MULTILINE
 )
 


### PR DESCRIPTION
# Description

- Fixed item base regex to work with multi-work item classes
- Fixed map crafting to clean-up the map before starting the crafting process
- Made t17 and non-t17 map crafting process only differ on declaration step